### PR TITLE
Connected Footer Contact Us button to Contact Us page

### DIFF
--- a/client/components/Footer.js
+++ b/client/components/Footer.js
@@ -17,7 +17,7 @@ const Footer = () => {
                         FAQ
                     </button>
                 </Link>
-                <Link href="/homepage" passHref>
+                <Link href="/contact" passHref>
                     <button className={styles.button}>
                         Contact Us
                     </button>


### PR DESCRIPTION
Changed the link for Contact Us in the Footer.js to link to /contact on line 20 as mentioned in standup earlier.