### PR TITLE
Fixed format of some school names and freshman schedule mistake

### DIFF
--- a/client/components/Layout.js
+++ b/client/components/Layout.js
@@ -6,12 +6,9 @@ import NavBar from "@/components/NavBar";
 const Layout = ({props}) => {
     return(
         <div>
-            {/* <Background> */}
-            <div style={{marginTop: "60px"}}/>
             <NavBar/>
             <ScrollUpButton/>
             {props}
-            {/* </Background> */}
         </div>
     )
 }

--- a/client/pages/_app.js
+++ b/client/pages/_app.js
@@ -10,8 +10,9 @@ export default function App({ Component, pageProps }) {
     <UserAuthContext>
       <main className={styles.container}>
         <section className={styles.main}>
-        <Layout/>
+        <div style={{marginTop: "60px"}}/>
         <Component {...pageProps} />
+        <Layout/>
         </section>
        <section className={styles.footeer}>
        <Footer/>

--- a/client/pages/compare.js
+++ b/client/pages/compare.js
@@ -168,6 +168,11 @@ function Compare() {
                                 school2_answer: school2ProfileData.psal_girls
                             },
                             {
+                                question: "What is the freshman schedule?",
+                                school1_answer: school1ProfileData.freshman_schedule,
+                                school2_answer: school2ProfileData.freshman_schedule
+                            },
+                            {
                                 question: "How many students go to this school?",
                                 school1_answer: school1ProfileData.total_students,
                                 school2_answer: school2ProfileData.total_students

--- a/client/pages/schools/[dbn].js
+++ b/client/pages/schools/[dbn].js
@@ -91,7 +91,7 @@ function SchoolProfile() {
                             <CardSquare text1={"Total Students"} text2={school.total_students} ></CardSquare>
                         </div>
                         <div className="p-2 bd-highlight">
-                            <CardSquare text1={"Freshman Schedule"} text2={school.freshmen_schedule} ></CardSquare>
+                            <CardSquare text1={"Freshman Schedule"} text2={school.freshman_schedule} ></CardSquare>
                         </div>
                         <div className="p-2 bd-highlight">
                             <CardSquare text1={"PSAL Boys"} text2={school.psal_boys} ></CardSquare>

--- a/server/data.js
+++ b/server/data.js
@@ -39,6 +39,10 @@ const fetchData = async () => {
     let img_url = "";
     let school_name_mod = "";
     for (let x = 0;x<school_data_json.length;x++) {
+        if (school_data_json[x].school_name.endsWith(", The")) {
+            school_data_json[x].school_name = school_data_json[x].school_name.slice(0, -5);
+            school_data_json[x].school_name = "The " + school_data_json[x].school_name;
+        }
         school_name_mod = school_data_json[x].school_name.split(' ').join('_');
         img_url = await fetchImg(school_name_mod);
         await School.create({ 


### PR DESCRIPTION
Description: Some school names from Open NYC data had ", The" at the end. Moved to the front of school name. In school profile, freshman schedule was not displaying because previously was calling it with a typo.

Files changed:
1. client/pages/schools/[dbn].js: fixed typo so freshman schedule will display on school profile if available now.
2. server/data.js: Fixed format for some school names that had ", The" at the end and moved to the front.
3. client/pages/_app.js: Put layout below component so it's props are not hidden by other components with smaller screen sizes.
4. client/components/Layout.js: Added margin here so that the NavBar doesn't cover titles.
5. client/pages/compare.js: Added freshman schedule to compare page.